### PR TITLE
Photo compression implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,6 +118,9 @@ dependencies {
     //Coil
     implementation("io.coil-kt:coil-compose:2.5.0")
 
+    //Image compression
+    implementation("id.zelory:compressor:3.0.1")
+
     //YCharts
     implementation("co.yml:ycharts:2.1.0")
 

--- a/app/src/main/java/com/mateusz113/financemanager/MainActivity.kt
+++ b/app/src/main/java/com/mateusz113/financemanager/MainActivity.kt
@@ -297,8 +297,22 @@ class MainActivity : ComponentActivity() {
         )
     }
 
+    private fun clearCache() {
+        try {
+            val cacheDir = applicationContext.cacheDir
+            if (cacheDir.exists()) {
+                cacheDir.listFiles()?.forEach { file ->
+                    file.delete()
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
     override fun onDestroy() {
         facebookAuthUiClient.unregisterCallback()
+        clearCache()
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/mateusz113/financemanager/domain/compressor/PhotoCompressor.kt
+++ b/app/src/main/java/com/mateusz113/financemanager/domain/compressor/PhotoCompressor.kt
@@ -1,0 +1,71 @@
+package com.mateusz113.financemanager.domain.compressor
+
+import android.content.Context
+import android.net.Uri
+import id.zelory.compressor.Compressor
+import id.zelory.compressor.constraint.destination
+import id.zelory.compressor.constraint.quality
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+
+class PhotoCompressor {
+    companion object {
+        /**
+         * Compresses the image, outputs it to the file and returns Uri of that file
+         * @param context Application context
+         * @param initialPhotoUri Uri of the photo that should be compressed
+         * @param outputFile File to which the photo should be outputted
+         */
+        suspend fun compressImage(
+            context: Context,
+            initialPhotoUri: Uri,
+            outputFile: File
+        ): Uri? {
+            return try {
+                val byteArray = getByteArrayFromUri(context, initialPhotoUri)
+                writeBiteArrayToFile(byteArray, outputFile)
+                Compressor.compress(context, outputFile) {
+                    destination(outputFile)
+                    quality(50)
+                }
+                getFileUri(outputFile)
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
+        }
+
+        private fun getByteArrayFromUri(
+            context: Context,
+            uri: Uri
+        ): ByteArray {
+            val inputStream = context.contentResolver.openInputStream(uri)
+            val buffer = ByteArrayOutputStream()
+            inputStream?.use { input ->
+                val bufferSize = 4096
+                val data = ByteArray(bufferSize)
+                var bytesRead: Int
+                while (input.read(data, 0, bufferSize).also { bytesRead = it } != -1) {
+                    buffer.write(data, 0, bytesRead)
+                }
+            }
+            return buffer.toByteArray()
+        }
+
+        private fun writeBiteArrayToFile(
+            byteArray: ByteArray,
+            file: File
+        ) {
+            val outputStream = FileOutputStream(file)
+            outputStream.write(byteArray)
+            outputStream.close()
+        }
+
+        private fun getFileUri(
+            file: File
+        ): Uri {
+            return Uri.fromFile(file)
+        }
+    }
+}

--- a/app/src/main/java/com/mateusz113/financemanager/domain/validator/PaymentPhotoSizeValidator.kt
+++ b/app/src/main/java/com/mateusz113/financemanager/domain/validator/PaymentPhotoSizeValidator.kt
@@ -6,8 +6,8 @@ import java.io.File
 
 class PaymentPhotoSizeValidator {
     companion object {
-        //Maximum upload size in 2 MB
-        private const val MAXIMUM_FILE_SIZE_IN_BYTES: Long = 2_097_152
+        //Maximum upload size in 4 MB
+        private const val MAXIMUM_FILE_SIZE_IN_BYTES: Long = 4_194_304
         fun validatePhotoSize(
             context: Context,
             uri: Uri

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,7 +109,8 @@
     <string name="payment_description_error">Payment description is too long or empty. It must be at most 500 characters long.</string>
     <string name="payment_amount_error">Amount value is too big or incorrectly formatted. The decimal point must be a dot. Maximum value is 6 digits long.</string>
     <string name="login_ui_provider_error">Incorrect value passed to external sign in button.</string>
-    <string name="photo_too_big">Selected photo is too large. Maximum upload size is 2MB.</string>
+    <string name="photo_too_big">Selected photo is too large. Maximum upload size is 4MB.</string>
+    <string name="photo_compression_failed">Photo compression failed. Try again.</string>
 
     //Sign in buttons content descriptions
     <string name="facebook_sign_in">Sign in with Facebook</string>


### PR DESCRIPTION
-Added the functionality of compressing the photos uploaded to the Firebase storage
-Updated the limit to the uploaded photos from 2MB to 4MB
-Added the cache clearing to the MainActivity onDestroy() as image compression uses space in cache dir